### PR TITLE
Add MedGemma client and WSI tools

### DIFF
--- a/patholens/app/agents/prompts/medgemma_prompts.py
+++ b/patholens/app/agents/prompts/medgemma_prompts.py
@@ -1,0 +1,17 @@
+# System instructions define the model's persona
+SYSTEM_INSTRUCTION_EXPERT_PATHOLOGIST = "You are an expert pathologist."
+SYSTEM_INSTRUCTION_NOTE_TAKER = "You are an expert pathologist creating a detailed note for a marked Region of Interest on a whole-slide image."
+SYSTEM_INSTRUCTION_CONCISE_OBSERVER = "You are an expert pathologist observing a specific region of a whole-slide image."
+
+# User-facing prompts for different tasks
+PROMPT_GLOBAL_SUMMARY = """
+Provide a concise overview of this whole-slide image. Focus on key pathological features, tissue types, and any apparent abnormalities. Keep the summary to a maximum of 150 words.
+"""
+
+PROMPT_SNAPSHOT_SUMMARY = """
+Briefly describe the most salient features in this image tile. What are the immediate observations? Limit your response to 1-2 sentences or a few bullet points (max 40 words).
+"""
+
+PROMPT_ROI_NOTE = """
+Analyze the provided image region. Describe the cellular morphology, tissue architecture, and any notable pathological findings. If applicable, suggest potential differential diagnoses or areas for further investigation. Be comprehensive but structured.
+"""

--- a/patholens/app/agents/tools/medgemma_tools.py
+++ b/patholens/app/agents/tools/medgemma_tools.py
@@ -1,0 +1,61 @@
+from google.adk.tools import FunctionTool, ToolContext
+from app.common.medgemma_client import MedGemmaClient
+from app.agents.prompts import medgemma_prompts
+from typing import Literal
+
+# This is a placeholder. In a real app, the client would be initialized
+# once and passed via context or a dependency injection system.
+# For now, we'll initialize it with placeholder values for structure.
+# In a later step, we'll get these values from environment variables.
+medgemma_client_instance = None # To be initialized later
+
+
+def _initialize_client():
+    """Lazy initializer for the client."""
+    global medgemma_client_instance
+    if medgemma_client_instance is None:
+        try:
+            from dotenv import load_dotenv
+            import os
+            load_dotenv()
+            medgemma_client_instance = MedGemmaClient(
+                project_id=os.getenv("GCP_PROJECT_ID", "placeholder"),
+                region=os.getenv("GCP_REGION", "placeholder"),
+                endpoint_id=os.getenv("MEDGEMMA_ENDPOINT_ID", "placeholder")
+            )
+        except (ValueError, ImportError) as e:
+            print(f"Could not initialize MedGemmaClient: {e}")
+            medgemma_client_instance = "Dummy" # Avoid re-initialization failure
+    return medgemma_client_instance
+
+PROMPT_MAPPING = {
+    "global_summary": (medgemma_prompts.SYSTEM_INSTRUCTION_EXPERT_PATHOLOGIST, medgemma_prompts.PROMPT_GLOBAL_SUMMARY),
+    "snapshot_summary": (medgemma_prompts.SYSTEM_INSTRUCTION_CONCISE_OBSERVER, medgemma_prompts.PROMPT_SNAPSHOT_SUMMARY),
+    "roi_note": (medgemma_prompts.SYSTEM_INSTRUCTION_NOTE_TAKER, medgemma_prompts.PROMPT_ROI_NOTE),
+}
+
+PromptKey = Literal["global_summary", "snapshot_summary", "roi_note"]
+
+
+def invoke_medgemma(image_gcs_uri: str, prompt_key: PromptKey, tool_context: ToolContext) -> str:
+    """
+    Sends an image (by GCS URI) and a selected prompt to the MedGemma Vertex AI endpoint for summarization.
+    """
+    client = _initialize_client()
+    if not isinstance(client, MedGemmaClient):
+        return "Error: MedGemma client is not available or failed to initialize."
+
+    if prompt_key not in PROMPT_MAPPING:
+        return f"Error: Invalid prompt key '{prompt_key}'. Valid keys are: {list(PROMPT_MAPPING.keys())}"
+
+    system_instruction, prompt = PROMPT_MAPPING[prompt_key]
+    
+    summary = client.generate_summary(
+        image_uri=image_gcs_uri,
+        prompt=prompt,
+        system_instruction=system_instruction
+    )
+    return summary
+
+
+invoke_medgemma_tool = FunctionTool.from_function(invoke_medgemma)

--- a/patholens/app/agents/tools/wsi_tools.py
+++ b/patholens/app/agents/tools/wsi_tools.py
@@ -1,0 +1,72 @@
+import io
+import openslide
+from PIL import Image
+from google.cloud import storage
+from google.adk.tools import FunctionTool, ToolContext
+from google.adk import types
+
+# This is a placeholder. In a real app, the GCS client would be initialized
+# once and passed via context or a dependency injection system.
+storage_client = None
+
+def _initialize_client():
+    """Lazy initializer for the GCS client."""
+    global storage_client
+    if storage_client is None:
+        try:
+            storage_client = storage.Client()
+        except Exception as e:
+            print(f"Could not initialize GCS client: {e}")
+            storage_client = "Dummy"
+    return storage_client
+
+def load_wsi_tile(slide_gcs_uri: str, x: int, y: int, width: int, height: int, level: int) -> Image.Image:
+    """
+    Fetches a specific tile/region from a WSI stored in GCS.
+    """
+    client = _initialize_client()
+    if not isinstance(client, storage.Client):
+        raise ConnectionError("GCS client is not available.")
+
+    bucket_name, blob_name = slide_gcs_uri.replace("gs://", "").split("/", 1)
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+
+    with io.BytesIO(blob.download_as_bytes()) as slide_bytes:
+        slide = openslide.OpenSlide(slide_bytes)
+        tile = slide.read_region((x, y), level, (width, height))
+        # Return as RGBA and then convert to RGB for consistency, as some formats have alpha channels
+        return tile.convert("RGB")
+
+def capture_snapshot(slide_id: str, x: int, y: int, width: int, height: int, level: int, tool_context: ToolContext) -> str:
+    """
+    Captures the current viewport or a specified ROI as an image,
+    saves it to the GCS Artifact Service, and returns its GCS URI.
+    """
+    # Assume slide_id can be resolved to a full GCS path.
+    # This logic will be improved later (e.g., fetching from a Firestore database).
+    slide_gcs_uri = f"gs://{tool_context.app_config.get('WSI_BUCKET')}/originals_for_viewer/{slide_id}"
+
+    try:
+        image = load_wsi_tile(slide_gcs_uri, x, y, width, height, level)
+        
+        # Convert PIL Image to bytes to save as an artifact
+        img_byte_arr = io.BytesIO()
+        image.save(img_byte_arr, format='PNG')
+        image_bytes = img_byte_arr.getvalue()
+        
+        # Use the ADK's artifact service to save the file
+        filename = f"snapshot_{slide_id}_L{level}_{x}_{y}.png"
+        part = types.Part.from_blob(image_bytes, "image/png")
+        
+        tool_context.save_artifact(filename, part)
+        
+        # Construct and return the GCS URI of the saved artifact
+        # The exact path is managed by the GcsArtifactService
+        artifact_uri = f"gs://{tool_context.artifact_service.bucket_name}/{tool_context.artifact_service.get_artifact_path(tool_context, filename)}"
+        return f"Successfully saved snapshot to {artifact_uri}"
+
+    except Exception as e:
+        return f"Error capturing snapshot: {e}"
+
+capture_snapshot_tool = FunctionTool.from_function(capture_snapshot)

--- a/patholens/app/common/medgemma_client.py
+++ b/patholens/app/common/medgemma_client.py
@@ -1,0 +1,67 @@
+import os
+from google.cloud import aiplatform
+
+class MedGemmaClient:
+    """A wrapper for interacting with a deployed MedGemma endpoint on Vertex AI."""
+
+    def __init__(self, project_id: str, region: str, endpoint_id: str):
+        """
+        Initializes the MedGemma client.
+
+        Args:
+            project_id: The Google Cloud project ID.
+            region: The region where the Vertex AI endpoint is deployed.
+            endpoint_id: The ID of the Vertex AI endpoint.
+        """
+        if not all([project_id, region, endpoint_id]):
+            raise ValueError("Project ID, region, and endpoint ID must be provided.")
+        
+        aiplatform.init(project=project_id, location=region)
+        self.endpoint = aiplatform.Endpoint(endpoint_name=endpoint_id)
+        print(f"MedGemmaClient initialized for endpoint: {self.endpoint.resource_name}")
+
+    def generate_summary(
+        self,
+        image_uri: str,
+        prompt: str,
+        system_instruction: str,
+        max_tokens: int = 512,
+        temperature: float = 0.2,
+    ) -> str:
+        """
+        Generates a summary for a given image using the MedGemma model.
+
+        Args:
+            image_uri: GCS URI of the image to analyze (e.g., "gs://bucket/image.png").
+            prompt: The user-facing prompt for the model.
+            system_instruction: The system-level instruction to guide the model's persona.
+            max_tokens: The maximum number of tokens to generate.
+            temperature: The sampling temperature for the generation.
+
+        Returns:
+            The generated text summary from the model.
+        """
+        full_prompt = f"{system_instruction} {prompt}"
+        
+        instances = [{
+            "prompt": full_prompt,
+            "multi_modal_data": {"image": image_uri},
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "raw_response": True,
+        }]
+
+        try:
+            response = self.endpoint.predict(instances=instances)
+            prediction = response.predictions[0] if response.predictions else ""
+            return prediction
+        except Exception as e:
+            print(f"Error calling MedGemma endpoint: {e}")
+            return f"Error: Could not get a response from the model. Details: {e}"
+
+# Example of how this might be instantiated in main.py later
+# medgemma_client = MedGemmaClient(
+#     project_id=os.getenv("GCP_PROJECT_ID"),
+#     region=os.getenv("GCP_REGION"),
+#     endpoint_id=os.getenv("MEDGEMMA_ENDPOINT_ID")
+# )

--- a/patholens/app/services/main.py
+++ b/patholens/app/services/main.py
@@ -73,6 +73,10 @@ async def root():
 
 # The agent interaction endpoint will be added in the next task.
 
+# Include the slide tiling router
+from . import slide_router
+app.include_router(slide_router.router)
+
 # --- Agent Interaction Endpoint ---
 
 from fastapi import Request

--- a/patholens/app/services/slide_router.py
+++ b/patholens/app/services/slide_router.py
@@ -1,0 +1,46 @@
+import io
+from fastapi import APIRouter, HTTPException, Depends
+from fastapi.responses import Response
+from app.agents.tools.wsi_tools import load_wsi_tile
+
+router = APIRouter()
+
+# This is a placeholder for getting app-level configuration.
+# In a real app, you might use FastAPI's dependency injection for settings.
+def get_wsi_bucket():
+    import os
+    return os.getenv("WSI_BUCKET", "your-wsi-bucket-name")
+
+
+@router.get("/tiles/{slide_id}/{level}/{x}_{y}.png", tags=["WSI Tiling"])
+async def get_wsi_tile(
+    slide_id: str,
+    level: int,
+    x: int,
+    y: int,
+    wsi_bucket: str = Depends(get_wsi_bucket)
+):
+    """
+    Serves a single tile from a Whole-Slide Image stored in GCS.
+    This endpoint is designed to be used by a tile viewer like OpenSeadragon.
+    """
+    try:
+        # Assumes tile size is known, e.g., 256x256. This could be a query param.
+        tile_size = 256
+
+        # The tile coordinate (x,y) from viewers is typically the top-left pixel of the tile.
+        # We need to map this to the level 0 coordinates that openslide expects.
+        # This is a simplified mapping; a real implementation would need slide-specific properties.
+        # For now, we assume x and y are already the level 0 coordinates.
+
+        slide_gcs_uri = f"gs://{wsi_bucket}/originals_for_viewer/{slide_id}"
+
+        # We use the existing tool's utility function
+        image = load_wsi_tile(slide_gcs_uri, x, y, tile_size, tile_size, level)
+
+        with io.BytesIO() as output:
+            image.save(output, format="PNG")
+            return Response(content=output.getvalue(), media_type="image/png")
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Could not retrieve WSI tile: {e}")


### PR DESCRIPTION
## Summary
- add MedGemma client for calling Vertex AI endpoint
- define MedGemma prompt templates
- implement MedGemma invocation tool for agents
- add WSI tile utilities and snapshot tool
- expose new tiling API router and hook it into the FastAPI app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684968c06e8c832ba7b90007485c0e0c