### PR TITLE
Implement snapshot manager agent and storage tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# --- GCP Configuration ---
+# Your Google Cloud Project ID
+GCP_PROJECT_ID="your-gcp-project-id"
+# The region for your GCP services (e.g., us-central1)
+GCP_REGION="us-central1"
+
+# --- Vertex AI MedGemma Configuration ---
+# The ID of your deployed MedGemma endpoint in Vertex AI
+MEDGEMMA_ENDPOINT_ID="your-medgemma-endpoint-id"
+
+# --- Cloud Storage Configuration ---
+# The GCS bucket for storing agent-generated artifacts (snapshots, etc.)
+GCS_ARTIFACT_BUCKET="your-patholens-artifacts-bucket"
+# The GCS bucket where original WSIs are stored for the tile viewer
+WSI_BUCKET="your-patholens-wsi-bucket"
+
+# --- Agent Model Configuration ---
+# The model to use for the root orchestration agent
+ROOT_AGENT_MODEL="gemini-1.5-flash-001"
+# The model to use for the snapshot manager agent
+SNAPSHOT_AGENT_MODEL="gemini-1.5-flash-001"
+

--- a/patholens/app/agents/core_agents.py
+++ b/patholens/app/agents/core_agents.py
@@ -4,7 +4,7 @@ from google.adk.agents import LlmAgent
 # In the future, we will import and define the sub-agents here.
 # For now, we will leave them as placeholder strings.
 # from .slide_manager import slide_manager_agent
-# from .snapshot_manager import snapshot_manager_agent
+from .snapshot_manager import snapshot_manager_agent
 
 # Define the instruction for the root agent. This guides its behavior.
 ROOT_AGENT_INSTRUCTION = """
@@ -29,7 +29,7 @@ root_agent = LlmAgent(
         # Placeholder agents. We will create these actual agent objects later.
         # For now, this structure allows the RootAgent to be aware of them.
         LlmAgent(name="SlideManagerAgent", description="Manages whole-slide image context and global summaries."),
-        LlmAgent(name="SnapshotManagerAgent", description="Analyzes real-time viewport snapshots."),
+        snapshot_manager_agent,
         LlmAgent(name="MarkedRegionManagerAgent", description="Processes user-marked Regions of Interest (ROIs)."),
         LlmAgent(name="UITelemetryCoordinatorAgent", description="Handles UI events and telemetry."),
     ],

--- a/patholens/app/agents/snapshot_manager.py
+++ b/patholens/app/agents/snapshot_manager.py
@@ -1,0 +1,28 @@
+import os
+from google.adk.agents import LlmAgent
+from .tools.wsi_tools import capture_snapshot_tool
+from .tools.medgemma_tools import invoke_medgemma_tool
+from .tools.storage_tools import update_recent_snapshots_tool, archive_note_tool
+
+SNAPSHOT_MANAGER_INSTRUCTION = """
+You are a specialized agent responsible for real-time analysis of a pathologist's current view.
+Your task is to process a specified region of a Whole-Slide Image (WSI).
+
+Workflow:
+1.  Use the `capture_snapshot_tool` to get an image of the specified slide region. This will save the image and give you its GCS URI.
+2.  Use the `invoke_medgemma_tool` with the GCS URI from the previous step and the 'snapshot_summary' prompt key to generate a brief description.
+3.  Use the `update_recent_snapshots_tool` to add the new snapshot's GCS URI and its summary to the session's memory.
+4.  Finally, output the summary you generated clearly to the user.
+"""
+
+snapshot_manager_agent = LlmAgent(
+    name="SnapshotManagerAgent",
+    model=os.getenv("SNAPSHOT_AGENT_MODEL", "gemini-1.5-flash"),
+    instruction=SNAPSHOT_MANAGER_INSTRUCTION,
+    tools=[
+        capture_snapshot_tool,
+        invoke_medgemma_tool,
+        update_recent_snapshots_tool,
+        # archive_note_tool will be used by the MarkedRegionManagerAgent later
+    ],
+)

--- a/patholens/app/agents/tools/storage_tools.py
+++ b/patholens/app/agents/tools/storage_tools.py
@@ -1,0 +1,72 @@
+from google.adk.tools import FunctionTool, ToolContext
+from google.cloud import firestore
+from datetime import datetime, timezone
+from typing import Optional
+
+# Placeholder for Firestore client
+db_client = None
+
+
+def _initialize_client():
+    """Lazy initializer for the Firestore client."""
+    global db_client
+    if db_client is None:
+        try:
+            db_client = firestore.Client()
+        except Exception as e:
+            print(f"Could not initialize Firestore client: {e}")
+            db_client = "Dummy"
+    return db_client
+
+
+def archive_note_to_firestore(
+    slide_id: str,
+    roi_snapshot_gcs_uri: str,
+    note_summary: str,
+    user_annotations: Optional[dict],
+    tool_context: ToolContext
+) -> str:
+    """
+    Saves a detailed note for a Region of Interest (ROI) to the 'pathology_notes' collection in Firestore.
+    """
+    client = _initialize_client()
+    if not isinstance(client, firestore.Client):
+        return "Error: Firestore client is not available."
+
+    try:
+        doc_ref = client.collection("pathology_notes").document()
+        doc_ref.set({
+            "slide_id": slide_id,
+            "roi_image_uri": roi_snapshot_gcs_uri,
+            "summary_text": note_summary,
+            "user_annotations": user_annotations or {},
+            "user_id": tool_context.session.user_id,
+            "timestamp": datetime.now(timezone.utc),
+        })
+        return f"Successfully archived note with ID: {doc_ref.id}"
+    except Exception as e:
+        return f"Error archiving note to Firestore: {e}"
+
+
+def update_recent_snapshots(snapshot_gcs_uri: str, summary: str, tool_context: ToolContext) -> str:
+    """
+    Adds the latest snapshot URI and its summary to a rolling list in the session state. Keeps the last 5.
+    """
+    if "recent_snapshots" not in tool_context.state:
+        tool_context.state["recent_snapshots"] = []
+
+    # Prepend the new snapshot to the list
+    tool_context.state["recent_snapshots"].insert(0, {
+        "image_uri": snapshot_gcs_uri,
+        "summary": summary,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    })
+
+    # Keep only the most recent 5 snapshots
+    tool_context.state["recent_snapshots"] = tool_context.state["recent_snapshots"][:5]
+
+    return "Successfully updated the list of recent snapshots in the session."
+
+
+archive_note_tool = FunctionTool.from_function(archive_note_to_firestore)
+update_recent_snapshots_tool = FunctionTool.from_function(update_recent_snapshots)


### PR DESCRIPTION
## Summary
- add `.env.example` with project configuration variables
- add `snapshot_manager_agent` with MedGemma summarization
- create Firestore and session storage tools
- integrate snapshot manager into the root agent

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68496a912a50832b916b81ead7f6152b